### PR TITLE
added step to verify delete success message to slow script down

### DIFF
--- a/src/tests/demoUI/pages/adminUserManagementPage.ts
+++ b/src/tests/demoUI/pages/adminUserManagementPage.ts
@@ -23,9 +23,7 @@ export class AdminUserManagementPage {
   private statusDropdown = "(//i[contains(@class, 'oxd-icon bi-caret-down-fill oxd-select-text--arrow')])[2]";
   private enabledListItem = "//div[@role='option']/span[text()='Enabled']"
   private yesDeleteButton = "//button[text()=' Yes, Delete ']";
-  //private employeeNameText = "//div[text()='Timothy Amiano']";
-  //private employeeNameListItem = "//span[text()='Timothy Lewis Amiano']";
-  //private deleteButton = "//div[text()='Timothy Amiano']/ancestor::div[contains(@class, 'oxd-table-row')]//i[@class='oxd-icon bi-trash']";
+  private deleteSuccessMessage = "//div[@class='oxd-toast-content oxd-toast-content--success']";
 
   // Methods to generate dynamic locators
   private getEmployeeNameTextLocator(employeeName: string): string {
@@ -71,6 +69,7 @@ export class AdminUserManagementPage {
     const employeeName = dataMap['Employee Name'];
     await UIActionUtilities.clickElement(this.page.locator(this.getDeleteButtonLocator(employeeName)));
     await UIActionUtilities.clickElement(this.page.locator(this.yesDeleteButton));
+    await UIActionUtilities.isElementVisible(this.page.locator(this.deleteSuccessMessage));
   }
 
 


### PR DESCRIPTION
- Updated Delete User to validate the delete toast message was displayed. This ensures that the delete was successful before closing the browser which sometimes can stop the deletion and prevent the user from being deleted.
- Successfully executed the regression tests
<img width="959" alt="image" src="https://github.com/user-attachments/assets/b1f3743c-e46a-48f8-99e5-4973ab5710fc" />
